### PR TITLE
Adding Linux Support - How much testing is required?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [package.metadata.docs.rs]
-default-target = "x86_64-pc-windows-msvc"
-targets = ["i686-pc-windows-msvc", "x86_64-pc-windows-msvc"]
+targets = ["i686-pc-windows-msvc", "x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]
 
 [lib]
 name = "pcan_basic_sys"

--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ Rust bindings for version `V4.6.0.600` of the [PCAN-Basic API](https://www.peak-
 
 ## Installation
 
-**Disclaimer**:
-> `pcan-basic-sys` is a Rust crate targeting the Windows platform. Other platforms, i.e., macOS and Linux are not supported.
-
 ### Windows
 
 - Install the [PCAN-Basic API](https://www.peak-system.com/quick/DrvSetup) driver
@@ -24,6 +21,13 @@ Rust bindings for version `V4.6.0.600` of the [PCAN-Basic API](https://www.peak-
 - Use `pcan-basic-sys` as a dependency
 
 If you choose `MSVC` you need to install the **Visual Studio** toolchain.
+
+### Linux
+- Install the [PCAN-Basic chardev Driver and API](https://www.peak-system.com/fileadmin/media/linux/index.htm)
+- Install Rust
+- Install a Rust Linux toolchain.
+- Use `pcan-basic-sys` as a dependency
+
 
 ## License / Terms of Usage
 
@@ -51,3 +55,4 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 * [Christopher Woodall](https://github.com/cwoodall)
 * [Tim Lucas Sabelmann](https://github.com/tsabelmann)
+* [Asimm Hirani](https://github.com/AsimmHirani)

--- a/build.rs
+++ b/build.rs
@@ -14,8 +14,12 @@ fn main() {
                 manifest_dir
             );
         }
+        // link against this library
+        println!("cargo:rustc-link-lib=PCANBasic");
+    } else {
+        // link against this library
+        println!("cargo:rustc-link-lib=pcanbasic");
     }
 
-    // link against this library
-    println!("cargo:rustc-link-lib=PCANBasic");
+    
 }

--- a/build.rs
+++ b/build.rs
@@ -20,6 +20,4 @@ fn main() {
         // link against this library
         println!("cargo:rustc-link-lib=pcanbasic");
     }
-
-    
 }


### PR DESCRIPTION
I got 2.0.2 to build on Linux 5.17.5-76051705-generic using peak-linux-driver version 8.14.0 and without changing the underlying PCAN header. How much additional testing is required to add Linux support? 